### PR TITLE
Set log level on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,8 +5,8 @@ PODS:
   - FMDB/standard (2.7.5)
   - snowplow_flutter_tracker (0.0.1):
     - Flutter
-    - SnowplowTracker (= 1.3.0)
-  - SnowplowTracker (1.3.0):
+    - SnowplowTracker (~> 1.6.2)
+  - SnowplowTracker (1.6.2):
     - FMDB (~> 2.6)
 
 DEPENDENCIES:
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  snowplow_flutter_tracker: 65f78d772888a270a3918d19d7fb194de1e580d0
-  SnowplowTracker: 91259853f3c0de00dc93aa67492e3d0166659643
+  snowplow_flutter_tracker: 0523a1ae143e4f8c6cc65bea62982b7f798f7c8f
+  SnowplowTracker: 6d37e5411b4bdc4c254ab19cb7df41e81bbd0a13
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/ios/Classes/TrackerUtil.swift
+++ b/ios/Classes/TrackerUtil.swift
@@ -28,6 +28,7 @@ struct TrackerUtil {
             SPTrackerBuilder?.setLifecycleEvents(dictionary?["lifecycleEvents"] as? Bool ?? false)
             SPTrackerBuilder?.setScreenContext(dictionary?["screenContext"] as? Bool ?? false)
             SPTrackerBuilder?.setInstallEvent(dictionary?["installTracking"] as? Bool ?? false)
+            SPTrackerBuilder?.setLogLevel(getLogLevel(rawValue: dictionary?["logLevel"] as? String))
         }
     }
     
@@ -36,6 +37,21 @@ struct TrackerUtil {
             SPEmitterBuilder?.setUrlEndpoint(dictionary?["uri"] as? String)
             SPEmitterBuilder?.setHttpMethod(getHttpMethod(httpMethodAsString: dictionary?["httpMethod"] as? String))
             SPEmitterBuilder?.setProtocol(getProtocol(protocolAsString: dictionary?["requestSecurity"] as? String))
+        }
+    }
+
+    private static func getLogLevel(rawValue: String?) -> SPLogLevel {
+        switch rawValue {
+        case "OFF":
+            return SPLogLevel.off
+        case "ERROR":
+            return SPLogLevel.error
+        case "DEBUG":
+            return SPLogLevel.debug
+        case "VERBOSE":
+            return SPLogLevel.verbose
+        default:
+            return SPLogLevel.off
         }
     }
     

--- a/ios/snowplow_flutter_tracker.podspec
+++ b/ios/snowplow_flutter_tracker.podspec
@@ -15,7 +15,7 @@ Snowplow event tracker for Flutter. Add analytics to your Flutter apps and games
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'SnowplowTracker', '1.3.0'
+  s.dependency 'SnowplowTracker', '~> 1.6.2'
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
Resolves #7.

The diagnostic feature was introduced in [release 1.5.0](https://github.com/snowplow/snowplow-objc-tracker/issues/533) and we were still using 1.4.1. 

I updated the iOS dependency on snowplow-objc-tracker to the latest version and set the log level on the SPTrackerBuilder instance in the TrackerUtils.

Side note: apparently `setCheckInterval` was deprecated and will no longer have an effect when setting it. I guess it's the same on Android, so we could potentially remove that option/mark it as deprecated in our Flutter lib.