### PR TITLE
Platform context and geo context

### DIFF
--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
@@ -2,6 +2,7 @@ package com.patricktailor.snowplow_flutter_tracker
 
 import android.content.Context
 import com.patricktailor.snowplow_flutter_tracker.util.EventUtil
+import com.patricktailor.snowplow_flutter_tracker.util.SubjectUtil
 import com.patricktailor.snowplow_flutter_tracker.util.TrackerUtil
 import com.snowplowanalytics.snowplow.tracker.Emitter
 import com.snowplowanalytics.snowplow.tracker.Tracker
@@ -16,34 +17,8 @@ class SnowplowFlutterTracker(private val context: Context) {
     }
 
     fun setSubject(json: Map<String, Any>?) {
-        if (json?.get("userId") != null) {
-            tracker.subject.setUserId(json["userId"] as String)
-        }
-        if (json?.get("viewportWidth") != null && json["viewportHeight"] != null) {
-            tracker.subject.setViewPort(json["viewportWidth"] as Int, json["viewportHeight"] as Int)
-        }
-        if (json?.get("screenResolutionWidth") != null && json["screenResolutionHeight"] != null) {
-            tracker.subject.setScreenResolution(json["screenResolutionWidth"] as Int, json["screenResolutionHeight"] as Int)
-        }
-        if (json?.get("colorDepth") != null) {
-            tracker.subject.setColorDepth(json["colorDepth"] as Int)
-        }
-        if (json?.get("timezone") != null) {
-            tracker.subject.setTimezone(json["timezone"] as String)
-        }
-        if (json?.get("ipAddress") != null) {
-            tracker.subject.setIpAddress(json["ipAddress"] as String)
-        }
-        if (json?.get("userAgent") != null) {
-            tracker.subject.setUseragent(json["userAgent"] as String)
-        }
-        if (json?.get("networkUserId") != null) {
-            tracker.subject.setNetworkUserId(json["networkUserId"] as String)
-        }
-        if (json?.get("domainUserId") != null) {
-            tracker.subject.setDomainUserId(json["domainUserId"] as String)
-        }
-    }
+        json?.let { SubjectUtil.configure(tracker.subject, it) }
+}
 
     fun trackSelfDescribingEvent(json: Map<String, Any>?) {
         val selfDescribing = EventUtil.getSelfDescribingEvent(json)

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/SubjectUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/SubjectUtil.kt
@@ -5,35 +5,34 @@ import com.snowplowanalytics.snowplow.tracker.Subject
 class SubjectUtil {
     companion object {
         fun configure(subject: Subject, json: Map<String, Any>) {
-            if (json?.get("userId") != null) {
+            if (json["userId"] != null) {
                 subject.setUserId(json["userId"] as String)
             }
-
-            if (json?.get("viewportWidth") != null && json["viewportHeight"] != null) {
+            if (json["viewportWidth"] != null && json["viewportHeight"] != null) {
                 subject.setViewPort(json["viewportWidth"] as Int, json["viewportHeight"] as Int)
             }
-            if (json?.get("screenResolutionWidth") != null && json["screenResolutionHeight"] != null) {
+            if (json["screenResolutionWidth"] != null && json["screenResolutionHeight"] != null) {
                 subject.setScreenResolution(json["screenResolutionWidth"] as Int, json["screenResolutionHeight"] as Int)
             }
-            if (json?.get("colorDepth") != null) {
+            if (json["colorDepth"] != null) {
                 subject.setColorDepth(json["colorDepth"] as Int)
             }
-            if (json?.get("timezone") != null) {
+            if (json["timezone"] != null) {
                 subject.setTimezone(json["timezone"] as String)
             }
-            if (json?.get("language") != null) {
+            if (json["language"] != null) {
                 subject.setLanguage(json["language"] as String)
             }
-            if (json?.get("ipAddress") != null) {
+            if (json["ipAddress"] != null) {
                 subject.setIpAddress(json["ipAddress"] as String)
             }
-            if (json?.get("userAgent") != null) {
+            if (json["userAgent"] != null) {
                 subject.setUseragent(json["userAgent"] as String)
             }
-            if (json?.get("networkUserId") != null) {
+            if (json["networkUserId"] != null) {
                 subject.setNetworkUserId(json["networkUserId"] as String)
             }
-            if (json?.get("domainUserId") != null) {
+            if (json["domainUserId"] != null) {
                 subject.setDomainUserId(json["domainUserId"] as String)
             }
         }

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/SubjectUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/SubjectUtil.kt
@@ -1,0 +1,41 @@
+package com.patricktailor.snowplow_flutter_tracker.util
+
+import com.snowplowanalytics.snowplow.tracker.Subject
+
+class SubjectUtil {
+    companion object {
+        fun configure(subject: Subject, json: Map<String, Any>) {
+            if (json?.get("userId") != null) {
+                subject.setUserId(json["userId"] as String)
+            }
+
+            if (json?.get("viewportWidth") != null && json["viewportHeight"] != null) {
+                subject.setViewPort(json["viewportWidth"] as Int, json["viewportHeight"] as Int)
+            }
+            if (json?.get("screenResolutionWidth") != null && json["screenResolutionHeight"] != null) {
+                subject.setScreenResolution(json["screenResolutionWidth"] as Int, json["screenResolutionHeight"] as Int)
+            }
+            if (json?.get("colorDepth") != null) {
+                subject.setColorDepth(json["colorDepth"] as Int)
+            }
+            if (json?.get("timezone") != null) {
+                subject.setTimezone(json["timezone"] as String)
+            }
+            if (json?.get("language") != null) {
+                subject.setLanguage(json["language"] as String)
+            }
+            if (json?.get("ipAddress") != null) {
+                subject.setIpAddress(json["ipAddress"] as String)
+            }
+            if (json?.get("userAgent") != null) {
+                subject.setUseragent(json["userAgent"] as String)
+            }
+            if (json?.get("networkUserId") != null) {
+                subject.setNetworkUserId(json["networkUserId"] as String)
+            }
+            if (json?.get("domainUserId") != null) {
+                subject.setDomainUserId(json["domainUserId"] as String)
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
@@ -29,14 +29,13 @@ class TrackerUtil {
             val appId = json["appId"] as String
             val subject = Subject.SubjectBuilder().build()
 
-            val mobileContext =  json["mobileContext"] as Boolean
-
             var builder = Tracker.TrackerBuilder(emitter, namespace, appId, context)
                     .subject(subject)
                     .base64(json["base64"] as Boolean)
                     .platform(DevicePlatforms.valueOf(json["devicePlatform"] as String))
                     .level(LogLevel.valueOf(json["logLevel"] as String))
-                    .mobileContext(mobileContext)
+                    .mobileContext(json["mobileContext"] as Boolean)
+                    .geoLocationContext(json["geoContext"] as Boolean)
                     .screenviewEvents(json["screenviewEvents"] as Boolean)
                     .applicationContext(json["applicationContext"] as Boolean)
                     .sessionContext(json["sessionContext"] as Boolean)
@@ -50,12 +49,6 @@ class TrackerUtil {
 
             val subjectConfiguration = json["subject"] as? Map<String, Any>
             if (subjectConfiguration != null) {
-                val enableMobileContext = mobileContext || subjectConfiguration["platformContext"] as Boolean
-
-                builder = builder
-                        .geoLocationContext(subjectConfiguration["geoContext"] as Boolean)
-                        .mobileContext(enableMobileContext)
-
                 SubjectUtil.configure(subject, subjectConfiguration)
             }
 

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
@@ -1,3 +1,4 @@
+
 package com.patricktailor.snowplow_flutter_tracker.util
 
 import android.content.Context
@@ -28,12 +29,14 @@ class TrackerUtil {
             val appId = json["appId"] as String
             val subject = Subject.SubjectBuilder().build()
 
+            val mobileContext =  json["mobileContext"] as Boolean
+
             var builder = Tracker.TrackerBuilder(emitter, namespace, appId, context)
                     .subject(subject)
                     .base64(json["base64"] as Boolean)
                     .platform(DevicePlatforms.valueOf(json["devicePlatform"] as String))
                     .level(LogLevel.valueOf(json["logLevel"] as String))
-                    .mobileContext(json["mobileContext"] as Boolean)
+                    .mobileContext(mobileContext)
                     .screenviewEvents(json["screenviewEvents"] as Boolean)
                     .applicationContext(json["applicationContext"] as Boolean)
                     .sessionContext(json["sessionContext"] as Boolean)
@@ -44,6 +47,17 @@ class TrackerUtil {
                     .screenContext(json["screenContext"] as Boolean)
                     .installTracking(json["installTracking"] as Boolean)
                     .applicationCrash(json["exceptionEvents"] as Boolean)
+
+            val subjectConfiguration = json["subject"] as? Map<String, Any>
+            if (subjectConfiguration != null) {
+                val enableMobileContext = mobileContext || subjectConfiguration["platformContext"] as Boolean
+
+                builder = builder
+                        .geoLocationContext(subjectConfiguration["geoContext"] as Boolean)
+                        .mobileContext(enableMobileContext)
+
+                SubjectUtil.configure(subject, subjectConfiguration)
+            }
 
             val gdprContext = json["gdprContext"] as? Map<String, Any>
             if (gdprContext != null) {

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
@@ -1,4 +1,3 @@
-
 package com.patricktailor.snowplow_flutter_tracker.util
 
 import android.content.Context

--- a/ios/Classes/SPSubject+Configuration.swift
+++ b/ios/Classes/SPSubject+Configuration.swift
@@ -15,7 +15,7 @@ extension SPSubject {
 
         if let viewportWidth = configuration["viewportWidth"] as? Int,
            let viewportHeight = configuration["viewportHeight"] as? Int {
-            setViewPortWithWidth(viewportWidth,andHeight: viewportHeight)
+            setViewPortWithWidth(viewportWidth, andHeight: viewportHeight)
         }
 
         if let screenResolutionWidth = configuration["screenResolutionWidth"] as? Int,

--- a/ios/Classes/SPSubject+Configuration.swift
+++ b/ios/Classes/SPSubject+Configuration.swift
@@ -1,0 +1,63 @@
+//
+//  SPSubject+Configuration.swift
+//  snowplow_flutter_tracker
+//
+//  Created by DanielDPeter on 07.04.21.
+//
+
+import SnowplowTracker
+
+extension SPSubject {
+    func configure(with configuration: [String: Any]) {
+        if configuration["platformContext"] as? Bool ?? false, getPlatformDict()?.getAsDictionary()?.isEmpty ?? true {
+            setPlatformDict()
+        }
+
+        if configuration["geoContext"] as? Bool ?? false,
+           getGeoLocationDict()?.isEmpty ?? true {
+            setGeoDict()
+        }
+
+        if let userId = configuration["userId"] as? String {
+            setUserId(userId)
+        }
+
+        if let viewportWidth = configuration["viewportWidth"] as? Int,
+           let viewportHeight = configuration["viewportHeight"] as? Int {
+            setViewPortWithWidth(viewportWidth,andHeight: viewportHeight)
+        }
+
+        if let screenResolutionWidth = configuration["screenResolutionWidth"] as? Int,
+           let screenResolutionHeight = configuration["screenResolutionHeight"] as? Int {
+            setResolutionWithWidth(screenResolutionWidth, andHeight: screenResolutionHeight)
+        }
+
+        if let colorDepth = configuration["colorDepth"] as? Int {
+            setColorDepth(colorDepth)
+        }
+
+        if let timezone = configuration["timezone"] as? String {
+            setTimezone(timezone)
+        }
+
+        if let language = configuration["language"] as? String {
+            setLanguage(language)
+        }
+
+        if let ipAddress = configuration["ipAddress"] as? String {
+            setIpAddress(ipAddress)
+        }
+
+        if let userAgent = configuration["userAgent"] as? String {
+            setUseragent(userAgent)
+        }
+
+        if let networkUserId = configuration["networkUserId"] as? String {
+            setNetworkUserId(networkUserId)
+        }
+
+        if let domainUserId = configuration["domainUserId"] as? String {
+            setDomainUserId(domainUserId)
+        }
+    }
+}

--- a/ios/Classes/SPSubject+Configuration.swift
+++ b/ios/Classes/SPSubject+Configuration.swift
@@ -9,15 +9,6 @@ import SnowplowTracker
 
 extension SPSubject {
     func configure(with configuration: [String: Any]) {
-        if configuration["platformContext"] as? Bool ?? false, getPlatformDict()?.getAsDictionary()?.isEmpty ?? true {
-            setPlatformDict()
-        }
-
-        if configuration["geoContext"] as? Bool ?? false,
-           getGeoLocationDict()?.isEmpty ?? true {
-            setGeoDict()
-        }
-
         if let userId = configuration["userId"] as? String {
             setUserId(userId)
         }

--- a/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
@@ -50,36 +50,10 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
     }
     
     private func onSetSubject(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
-        let arguments = call.arguments as? [String: Any]
-        
-        if (arguments?["userId"] != nil) {
-            tracker?.subject.setUserId(arguments?["userId"] as? String)
+        if let subjectConfiguration = call.arguments as? [String: Any] {
+            tracker?.subject.configure(with: subjectConfiguration)
         }
-        if (arguments?["viewportWidth"] != nil && arguments?["viewportHeight"] != nil) {
-            tracker?.subject.setViewPortWithWidth(arguments?["viewportWidth"] as! Int, andHeight: arguments?["viewportHeight"] as! Int)
-        }
-        if (arguments?["screenResolutionWidth"] != nil && arguments?["screenResolutionHeight"] != nil) {
-            tracker?.subject.setResolutionWithWidth(arguments?["screenResolutionWidth"] as! Int, andHeight: arguments?["screenResolutionHeight"] as! Int)
-        }
-        if (arguments?["colorDepth"] != nil) {
-            tracker?.subject.setColorDepth(arguments?["colorDepth"] as! Int)
-        }
-        if (arguments?["timezone"] != nil) {
-            tracker?.subject.setTimezone(arguments?["timezone"] as? String)
-        }
-        if (arguments?["ipAddress"] != nil) {
-            tracker?.subject.setIpAddress(arguments?["ipAddress"] as? String)
-        }
-        if (arguments?["userAgent"] != nil) {
-            tracker?.subject.setUseragent(arguments?["userAgent"] as? String)
-        }
-        if (arguments?["networkUserId"] != nil) {
-            tracker?.subject.setNetworkUserId(arguments?["networkUserId"] as? String)
-        }
-        if (arguments?["domainUserId"] != nil) {
-            tracker?.subject.setDomainUserId(arguments?["domainUserId"] as? String)
-        }
-        
+
         result(nil)
     }
     

--- a/ios/Classes/TrackerUtil.swift
+++ b/ios/Classes/TrackerUtil.swift
@@ -10,8 +10,12 @@ import SnowplowTracker
 
 struct TrackerUtil {
     static func getTracker(emitter: SPEmitter, dictionary: [String: Any]?) -> SPTracker? {
-        let subject = SPSubject.init()
-        
+        let subject = SPSubject()!
+
+        if let subjectConfiguration = dictionary?["subject"] as? [String: Any] {
+            subject.configure(with: subjectConfiguration)
+        }
+
         return SPTracker.build { (SPTrackerBuilder) in
             SPTrackerBuilder?.setEmitter(emitter)
             SPTrackerBuilder?.setTrackerNamespace(dictionary?["namespace"] as? String)

--- a/ios/Classes/TrackerUtil.swift
+++ b/ios/Classes/TrackerUtil.swift
@@ -10,7 +10,10 @@ import SnowplowTracker
 
 struct TrackerUtil {
     static func getTracker(emitter: SPEmitter, dictionary: [String: Any]?) -> SPTracker? {
-        let subject = SPSubject()!
+        let subject = SPSubject(
+            platformContext: dictionary?["mobileContext"] as? Bool ?? false,
+            andGeoContext: dictionary?["geoContext"] as? Bool ?? false
+        )!
 
         if let subjectConfiguration = dictionary?["subject"] as? [String: Any] {
             subject.configure(with: subjectConfiguration)

--- a/lib/src/tracker/subject.dart
+++ b/lib/src/tracker/subject.dart
@@ -3,6 +3,14 @@ import 'package:flutter/foundation.dart';
 /// [Subject] This class is used to access and persist user information, it represents the current user being tracked.
 @immutable
 class Subject {
+  /// [platformContext] Whether to enable the platform context.
+  ///
+  /// Enabling the platform context on Android enables the mobile context.
+  final bool platformContext;
+
+  /// [geoContext] Whether to enabled the geolocation context.
+  final bool geoContext;
+
   /// [userId] The user's ID.
   final String? userId;
 
@@ -41,6 +49,8 @@ class Subject {
 
   /// Creates a [Subject]
   Subject({
+    this.platformContext = false,
+    this.geoContext = false,
     this.userId,
     this.viewportWidth,
     this.viewportHeight,
@@ -58,6 +68,8 @@ class Subject {
   /// [toMap] Converts the subject object to JSON.
   Map<String, Object?> toMap() {
     return {
+      'platformContext': platformContext,
+      'geoContext': geoContext,
       'userId': userId,
       'viewportWidth': viewportWidth,
       'viewportHeight': viewportHeight,

--- a/lib/src/tracker/subject.dart
+++ b/lib/src/tracker/subject.dart
@@ -3,14 +3,6 @@ import 'package:flutter/foundation.dart';
 /// [Subject] This class is used to access and persist user information, it represents the current user being tracked.
 @immutable
 class Subject {
-  /// [platformContext] Whether to enable the platform context.
-  ///
-  /// Enabling the platform context on Android enables the mobile context.
-  final bool platformContext;
-
-  /// [geoContext] Whether to enabled the geolocation context.
-  final bool geoContext;
-
   /// [userId] The user's ID.
   final String? userId;
 
@@ -49,8 +41,6 @@ class Subject {
 
   /// Creates a [Subject]
   Subject({
-    this.platformContext = false,
-    this.geoContext = false,
     this.userId,
     this.viewportWidth,
     this.viewportHeight,
@@ -68,8 +58,6 @@ class Subject {
   /// [toMap] Converts the subject object to JSON.
   Map<String, Object?> toMap() {
     return {
-      'platformContext': platformContext,
-      'geoContext': geoContext,
       'userId': userId,
       'viewportWidth': viewportWidth,
       'viewportHeight': viewportHeight,

--- a/lib/src/tracker/tracker.dart
+++ b/lib/src/tracker/tracker.dart
@@ -33,7 +33,11 @@ class Tracker {
   final LogLevel logLevel;
 
   /// [mobileContext] Whether mobile context is enabled.
+  /// The mobile context contains information like OS version, device model, carrier and more.
   final bool mobileContext;
+
+  /// [geoContext] Whether to enable the geolocation context.
+  final bool geoContext;
 
   /// [screenViewEvents] Whether to auto-track screen views.
   final bool screenViewEvents;
@@ -80,6 +84,7 @@ class Tracker {
     this.devicePlatform = DevicePlatforms.mobile,
     this.logLevel = LogLevel.off,
     this.mobileContext = false,
+    this.geoContext = false,
     this.screenViewEvents = false,
     this.applicationContext = false,
     this.sessionContext = false,
@@ -104,6 +109,7 @@ class Tracker {
       'devicePlatform': devicePlatform.name,
       'logLevel': logLevel.name,
       'mobileContext': mobileContext,
+      'geoContext': geoContext,
       'screenviewEvents': screenViewEvents,
       'applicationContext': applicationContext,
       'sessionContext': sessionContext,

--- a/lib/src/tracker/tracker.dart
+++ b/lib/src/tracker/tracker.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'gdpr_context.dart';
 import 'device_platforms.dart';
 import 'log_level.dart';
+import 'subject.dart';
 
 import '../emitter/emitter.dart';
 
@@ -10,6 +11,9 @@ import '../emitter/emitter.dart';
 /// This class is used for tracking events, and delegates them to other classes responsible for sending, storage, etc.
 @immutable
 class Tracker {
+  /// [subject]
+  final Subject? subject;
+
   /// [emitter] The emitter used by the tracker.
   final Emitter emitter;
 
@@ -68,6 +72,7 @@ class Tracker {
 
   /// Create a [Tracker] with default settings
   Tracker({
+    this.subject,
     required this.emitter,
     required this.namespace,
     required this.appId,
@@ -91,6 +96,7 @@ class Tracker {
   /// [toMap] Converts the tracker object to JSON.
   Map<String, Object?> toMap() {
     return <String, Object?>{
+      'subject': subject?.toMap(),
       'emitter': emitter.toMap(),
       'namespace': namespace,
       'appId': appId,


### PR DESCRIPTION
Resolves #10.

~~Needs rebasing after merging #17 as it builds on top of the previous work. Will take care of that. :)~~ Rebased and ready to review! :)

Based on the [Android documentation](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/android-tracker/android-1-7-0/), mobile context is the same as platform context on iOS. Therefore, whenever either the mobile context or the platform context are enabled, we enable the platform context.