### PR TITLE
Adds AbstractTracker

### DIFF
--- a/lib/snowplow_flutter_tracker.dart
+++ b/lib/snowplow_flutter_tracker.dart
@@ -5,6 +5,7 @@ export 'src/emitter/emitter.dart';
 export 'src/emitter/http_method.dart';
 export 'src/emitter/request_security.dart';
 
+export 'src/events/abstract_event.dart';
 export 'src/events/consent_document.dart';
 export 'src/events/consent_granted.dart';
 export 'src/events/consent_withdrawn.dart';
@@ -19,10 +20,12 @@ export 'src/events/self_describing_json.dart';
 export 'src/events/structured.dart';
 export 'src/events/timing.dart';
 
+export 'src/tracker/abstract_tracker.dart';
 export 'src/tracker/gdpr_context.dart';
 export 'src/tracker/device_platforms.dart';
 export 'src/tracker/log_level.dart';
 export 'src/tracker/subject.dart';
 export 'src/tracker/tracker.dart';
+export 'src/tracker/trackers/consentual_tracker.dart';
 
 export 'src/snowplow_flutter_tracker.dart';

--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -13,12 +13,13 @@ import 'events/screen_view.dart';
 import 'events/self_describing.dart';
 import 'events/structured.dart';
 import 'events/timing.dart';
+import 'tracker/abstract_tracker.dart';
 import 'tracker/subject.dart';
 import 'tracker/tracker.dart';
 
 /// [SnowplowFlutterTracker]
 /// The class which communicates with the current platform.
-class SnowplowFlutterTracker {
+class SnowplowFlutterTracker extends AbstractTracker {
   static final SnowplowFlutterTracker _singleton =
       SnowplowFlutterTracker._internal();
   static final MethodChannel _channel =
@@ -43,8 +44,7 @@ class SnowplowFlutterTracker {
     return await _channel.invokeMethod('setSubject', subject.toMap());
   }
 
-  /// [track]
-  /// Tracks the given [event] parameter by the platform's tracker instance.
+  @override
   Future<void> track(AbstractEvent event) async {
     if (event is SelfDescribing) {
       return await _channel.invokeMethod('trackSelfDescribing', event.toMap());

--- a/lib/src/tracker/abstract_tracker.dart
+++ b/lib/src/tracker/abstract_tracker.dart
@@ -5,6 +5,9 @@ import '../events/abstract_event.dart';
 /// [AbstractTracker]
 /// An abstract tracker allows to track events
 abstract class AbstractTracker {
+  /// default init
+  const AbstractTracker();
+
   /// [track]
   /// Tracks the given [event] parameter by the platform's tracker instance.
   Future<void> track(AbstractEvent event);

--- a/lib/src/tracker/abstract_tracker.dart
+++ b/lib/src/tracker/abstract_tracker.dart
@@ -1,0 +1,11 @@
+import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
+
+import '../events/abstract_event.dart';
+
+/// [AbstractTracker]
+/// An abstract tracker allows to track events
+abstract class AbstractTracker {
+  /// [track]
+  /// Tracks the given [event] parameter by the platform's tracker instance.
+  Future<void> track(AbstractEvent event);
+}

--- a/lib/src/tracker/trackers/consentual_tracker.dart
+++ b/lib/src/tracker/trackers/consentual_tracker.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../abstract_tracker.dart';
 import '../../events/abstract_event.dart';
 
@@ -6,12 +8,13 @@ import '../../events/abstract_event.dart';
 ///
 /// ConsentualTrackers can be used to block events from tracking
 /// when the user has not consented to tracking.
+@immutable
 class ConsentualTracker extends AbstractTracker {
   final AbstractTracker _wrapped;
   final Future<bool> Function() _condition;
 
   /// default initialiser
-  ConsentualTracker(
+  const ConsentualTracker(
     this._wrapped,
     this._condition,
   );

--- a/lib/src/tracker/trackers/consentual_tracker.dart
+++ b/lib/src/tracker/trackers/consentual_tracker.dart
@@ -1,0 +1,25 @@
+import '../abstract_tracker.dart';
+import '../../events/abstract_event.dart';
+
+/// [ConsentualTracker]
+/// Only tracks events if a pre-defined condition is met.
+///
+/// ConsentualTrackers can be used to block events from tracking
+/// when the user has not consented to tracking.
+class ConsentualTracker extends AbstractTracker {
+  final AbstractTracker _wrapped;
+  final Future<bool> Function() _condition;
+
+  /// default initialiser
+  ConsentualTracker(
+    this._wrapped,
+    this._condition,
+  );
+
+  @override
+  Future<void> track(AbstractEvent event) async {
+    if (await _condition()) {
+      return _wrapped.track(event);
+    }
+  }
+}

--- a/test/consentual_tracker_test.dart
+++ b/test/consentual_tracker_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
+
+class MockTracker extends AbstractTracker {
+  var trackedEvents = <AbstractEvent>[];
+
+  @override
+  Future<void> track(AbstractEvent event) async {
+    trackedEvents.add(event);
+  }
+}
+
+void main() {
+  final event = ScreenView(name: 'name');
+
+  test(
+    'If condition is true, ConsentualTracker forwards events',
+    () async {
+      final mock = MockTracker();
+
+      final sut = ConsentualTracker(
+        mock,
+        () async => true,
+      );
+
+      await sut.track(event);
+
+      expect(mock.trackedEvents, equals([event]));
+    },
+  );
+
+  test(
+    'If condition is false, ConsentualTracker does not forward events',
+    () async {
+      final mock = MockTracker();
+
+      final sut = ConsentualTracker(
+        mock,
+        () async => false,
+      );
+
+      await sut.track(event);
+
+      expect(mock.trackedEvents, equals([]));
+    },
+  );
+}


### PR DESCRIPTION
This PR adds AbstractTracker and ConsentualTracker (as an example) which will allows us to compose trackers using the decorator pattern.

Future improvements:
* Allow destroying trackers to turn off install / crash event tracking, if the user revokes their tracking consent. 
* Generic .initialize that allows reinitialising trackers, when the user re-granted consent. 

AbstractTracker is also easier to inject in tests as it only exposes the tracking functionality and does not 'care' about the initialising / setting subjects.