### PR TITLE
Adds initialise and destroy to AbstractTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ final tracker = Tracker(
     namespace: 'your-namespace',
     appId: 'your-appId',
 );
-var _tracker = SnowplowFlutterTracker();
-_tracker.initialize(tracker);
+var _tracker = SnowplowFlutterTracker(tracker);
+_tracker.initialize();
 
 // Usage
 final selfDescribingJson = SelfDescribingJson(

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
@@ -48,8 +48,8 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
             "trackConsentWithdrawn" -> {
                 onTrackConsentWithdrawn(call, result)
             }
-            "destroy" -> {
-                onDestroy(call, result)
+            "close" -> {
+                onClose(call, result)
             }
             else -> {
                 result.notImplemented()
@@ -138,7 +138,7 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
         result.success(null)
     }
 
-    private fun onDestroy(call: MethodCall, result: MethodChannel.Result) {
+    private fun onClose(call: MethodCall, result: MethodChannel.Result) {
         tracker?.close()
         tracker = null
         result.success(null)

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
@@ -1,5 +1,6 @@
 package com.patricktailor.snowplow_flutter_tracker
 
+import android.content.Context
 import android.util.Log
 import androidx.annotation.Nullable
 import io.flutter.plugin.common.BinaryMessenger
@@ -7,8 +8,9 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 
-class MethodCallHandlerImpl(private val tracker: SnowplowFlutterTracker) : MethodCallHandler {
+class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
     @Nullable private var channel: MethodChannel? = null
+    @Nullable private var tracker: SnowplowFlutterTracker? = null
 
     companion object {
         const val TAG = "MethodCallHandlerImpl"
@@ -46,6 +48,9 @@ class MethodCallHandlerImpl(private val tracker: SnowplowFlutterTracker) : Metho
             "trackConsentWithdrawn" -> {
                 onTrackConsentWithdrawn(call, result)
             }
+            "destroy" -> {
+                onDestroy(call, result)
+            }
             else -> {
                 result.notImplemented()
             }
@@ -74,61 +79,68 @@ class MethodCallHandlerImpl(private val tracker: SnowplowFlutterTracker) : Metho
 
     private fun onInitialize(call: MethodCall, result: MethodChannel.Result) {
         val trackerJson: Map<String, Any>? = call.arguments as? Map<String, Any>
-        tracker.initialize(trackerJson)
+        tracker = SnowplowFlutterTracker(context);
+        tracker?.initialize(trackerJson)
         result.success(null)
     }
 
     private fun onSetSubject(call: MethodCall, result: MethodChannel.Result) {
         val subjectJson = call.arguments as Map<String, Any>?
-        tracker.setSubject(subjectJson)
+        tracker?.setSubject(subjectJson)
         result.success(null)
     }
 
     private fun onTrackSelfDescribing(call: MethodCall, result: MethodChannel.Result) {
         val selfDescribingJson = call.arguments as Map<String, Any>?
-        tracker.trackSelfDescribingEvent(selfDescribingJson)
+        tracker?.trackSelfDescribingEvent(selfDescribingJson)
         result.success(null)
     }
 
     private fun onTrackStructured(call: MethodCall, result: MethodChannel.Result) {
         val structuredJson = call.arguments as Map<String, Any>?
-        tracker.trackStructuredEvent(structuredJson)
+        tracker?.trackStructuredEvent(structuredJson)
         result.success(null)
     }
 
     private fun onTrackScreenView(call: MethodCall, result: MethodChannel.Result) {
         val screenViewJson = call.arguments as Map<String, Any>?
-        tracker.trackScreenViewEvent(screenViewJson)
+        tracker?.trackScreenViewEvent(screenViewJson)
         result.success(null)
     }
 
     private fun onTrackPageView(call: MethodCall, result: MethodChannel.Result) {
         val pageViewJson = call.arguments as Map<String, Any>?
-        tracker.trackPageViewEvent(pageViewJson)
+        tracker?.trackPageViewEvent(pageViewJson)
         result.success(null)
     }
 
     private fun onTrackTiming(call: MethodCall, result: MethodChannel.Result) {
         val timingJson = call.arguments as Map<String, Any>?
-        tracker.trackTimingEvent(timingJson)
+        tracker?.trackTimingEvent(timingJson)
         result.success(null)
     }
 
     private fun onTrackEcommerceTransaction(call: MethodCall, result: MethodChannel.Result) {
         val ecommerceTransactionJson = call.arguments as Map<String, Any>?
-        tracker.trackEcommerceTransaction(ecommerceTransactionJson)
+        tracker?.trackEcommerceTransaction(ecommerceTransactionJson)
         result.success(null)
     }
 
     private fun onTrackConsentGranted(call: MethodCall, result: MethodChannel.Result) {
         val consentGrantedJson = call.arguments as Map<String, Any>?
-        tracker.trackConsentGranted(consentGrantedJson)
+        tracker?.trackConsentGranted(consentGrantedJson)
         result.success(null)
     }
 
     private fun onTrackConsentWithdrawn(call: MethodCall, result: MethodChannel.Result) {
         val consentWithdrawnJson = call.arguments as Map<String, Any>?
-        tracker.trackConsentWithdrawn(consentWithdrawnJson)
+        tracker?.trackConsentWithdrawn(consentWithdrawnJson)
+        result.success(null)
+    }
+
+    private fun onDestroy(call: MethodCall, result: MethodChannel.Result) {
+        tracker?.close()
+        tracker = null
         result.success(null)
     }
 }

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
@@ -59,4 +59,8 @@ class SnowplowFlutterTracker(private val context: Context) {
         val consentWithdrawn = EventUtil.getConsentWithdrawnEvent(json)
         tracker.track(consentWithdrawn)
     }
+
+    fun close() {
+        Tracker.close()
+    }
 }

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTrackerPlugin.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTrackerPlugin.kt
@@ -8,11 +8,9 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class SnowplowFlutterTrackerPlugin: FlutterPlugin {
   @Nullable private var methodCallHandler: MethodCallHandlerImpl? = null
-  @Nullable private var snowplowFlutterTracker: SnowplowFlutterTracker? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    snowplowFlutterTracker = SnowplowFlutterTracker(flutterPluginBinding.applicationContext)
-    methodCallHandler = MethodCallHandlerImpl(snowplowFlutterTracker!!)
+    methodCallHandler = MethodCallHandlerImpl(flutterPluginBinding.applicationContext)
     methodCallHandler!!.startListening(flutterPluginBinding.binaryMessenger)
   }
 
@@ -21,7 +19,7 @@ class SnowplowFlutterTrackerPlugin: FlutterPlugin {
 
     @JvmStatic
     fun registerWith(registrar: Registrar) {
-      val handler = MethodCallHandlerImpl(SnowplowFlutterTracker(registrar.context()))
+      val handler = MethodCallHandlerImpl(registrar.context())
       handler.startListening(registrar.messenger())
     }
   }
@@ -34,6 +32,5 @@ class SnowplowFlutterTrackerPlugin: FlutterPlugin {
 
     methodCallHandler!!.stopListening()
     methodCallHandler = null
-    snowplowFlutterTracker = null
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,8 +25,8 @@ class _MyAppState extends State<MyApp> {
       appId: 'your-appId',
       logLevel: LogLevel.verbose,
     );
-    _tracker = SnowplowFlutterTracker();
-    _tracker.initialize(tracker);
+    _tracker = SnowplowFlutterTracker(tracker);
+    _tracker.initialize();
 
     super.initState();
   }

--- a/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
@@ -35,6 +35,8 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
             onTrackEcommTransaction(call, result)
         case "trackPushNotification":
             onTrackPushNotification(call, result)
+        case "destroy":
+            onDestroy(call, result)
         default:
             result(FlutterMethodNotImplemented)
             return
@@ -59,64 +61,70 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
     
     private func onTrackPageView(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getPageView(dict: call.arguments as? [String: Any])
-        tracker?.trackPageViewEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackStructured(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getStructured(dict: call.arguments as? [String: Any])
-        tracker?.trackStructuredEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackUnstructured(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getUnstructured(dict: call.arguments as? [String: Any])
-        tracker?.trackUnstructuredEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackScreenView(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getScreenView(dict: call.arguments as? [String: Any])
-        tracker?.trackScreenViewEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackConsentWithdrawn(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getConsentWithdrawn(dict: call.arguments as? [String: Any])
-        tracker?.trackConsentWithdrawnEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackConsentGranted(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getConsentGranted(dict: call.arguments as? [String: Any])
-        tracker?.trackConsentGrantedEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackTiming(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getTiming(dict: call.arguments as? [String: Any])
-        tracker?.trackTimingEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackEcommTransaction(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getEcommTransaction(dict: call.arguments as? [String: Any])
-        tracker?.trackEcommerceEvent(event)
+        tracker?.track(event)
         
         result(nil)
     }
     
     private func onTrackPushNotification(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let event = EventUtil.getPushNotification(dict: call.arguments as? [String: Any])
-        tracker?.trackPushNotificationEvent(event)
+        tracker?.track(event)
         
+        result(nil)
+    }
+
+    private func onDestroy(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        tracker?.pauseEventTracking()
+        tracker = nil
         result(nil)
     }
 }

--- a/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
@@ -35,8 +35,8 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
             onTrackEcommTransaction(call, result)
         case "trackPushNotification":
             onTrackPushNotification(call, result)
-        case "destroy":
-            onDestroy(call, result)
+        case "close":
+            onClose(call, result)
         default:
             result(FlutterMethodNotImplemented)
             return
@@ -122,7 +122,7 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
 
-    private func onDestroy(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    private func onClose(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         tracker?.pauseEventTracking()
         tracker = nil
         result(nil)

--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -88,7 +88,7 @@ class SnowplowFlutterTracker extends AbstractTracker {
   }
 
   @override
-  Future<void> destroy() async {
-    return _channel.invokeMethod('destroy');
+  Future<void> close() async {
+    return _channel.invokeMethod('close');
   }
 }

--- a/lib/src/tracker/abstract_tracker.dart
+++ b/lib/src/tracker/abstract_tracker.dart
@@ -8,7 +8,15 @@ abstract class AbstractTracker {
   /// default init
   const AbstractTracker();
 
+  /// [initialize]
+  /// Initializes the tracker.
+  Future<void> initialize();
+
   /// [track]
   /// Tracks the given [event] parameter by the platform's tracker instance.
   Future<void> track(AbstractEvent event);
+
+  /// [destroy]
+  /// Deallocates the underlying tracker instance.
+  Future<void> destroy();
 }

--- a/lib/src/tracker/abstract_tracker.dart
+++ b/lib/src/tracker/abstract_tracker.dart
@@ -16,7 +16,7 @@ abstract class AbstractTracker {
   /// Tracks the given [event] parameter by the platform's tracker instance.
   Future<void> track(AbstractEvent event);
 
-  /// [destroy]
-  /// Deallocates the underlying tracker instance.
-  Future<void> destroy();
+  /// [close]
+  /// Deallocates the underlying tracker instance and stops all tracking.
+  Future<void> close();
 }

--- a/lib/src/tracker/trackers/consentual_tracker.dart
+++ b/lib/src/tracker/trackers/consentual_tracker.dart
@@ -14,6 +14,7 @@ class ConsentualTracker extends AbstractTracker {
   final ValueNotifier<bool> _condition;
 
   AbstractTracker? _wrapped;
+  bool _isInitialised = false;
 
   /// default initialiser
   ConsentualTracker(
@@ -23,8 +24,11 @@ class ConsentualTracker extends AbstractTracker {
 
   @override
   Future<void> initialize() async {
-    _condition.addListener(_onConsentChange);
-    _onConsentChange();
+    if (!_isInitialised) {
+      _condition.addListener(_onConsentChange);
+      _onConsentChange();
+      _isInitialised = true;
+    }
   }
 
   void _onConsentChange() async {
@@ -46,5 +50,6 @@ class ConsentualTracker extends AbstractTracker {
     _condition.removeListener(_onConsentChange);
     await _wrapped?.destroy();
     _wrapped = null;
+    _isInitialised = false;
   }
 }

--- a/lib/src/tracker/trackers/consentual_tracker.dart
+++ b/lib/src/tracker/trackers/consentual_tracker.dart
@@ -37,7 +37,7 @@ class ConsentualTracker extends AbstractTracker {
       _wrapped = _buildWrapped();
       await _wrapped?.initialize();
     } else if (!userConsented) {
-      await _wrapped?.destroy();
+      await _wrapped?.close();
       _wrapped = null;
     }
   }
@@ -46,9 +46,9 @@ class ConsentualTracker extends AbstractTracker {
   Future<void> track(AbstractEvent event) async => await _wrapped?.track(event);
 
   @override
-  Future<void> destroy() async {
+  Future<void> close() async {
     _condition.removeListener(_onConsentChange);
-    await _wrapped?.destroy();
+    await _wrapped?.close();
     _wrapped = null;
     _isInitialised = false;
   }

--- a/test/consentual_tracker_test.dart
+++ b/test/consentual_tracker_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
 
@@ -30,16 +31,14 @@ void main() {
     () async {
       final mock = MockTracker();
 
-      final streamController = StreamController<bool>(sync: true);
+      final valueNotifier = ValueNotifier<bool>(true);
 
       final sut = ConsentualTracker(
         () => mock,
-        streamController.stream,
+        valueNotifier,
       );
 
       await sut.initialize();
-
-      streamController.add(true);
 
       expect(mock.initializeInvocationCounter, equals(1));
 
@@ -54,16 +53,14 @@ void main() {
     () async {
       final mock = MockTracker();
 
-      final streamController = StreamController<bool>(sync: true);
+      final valueNotifier = ValueNotifier<bool>(false);
 
       final sut = ConsentualTracker(
         () => mock,
-        streamController.stream,
+        valueNotifier,
       );
 
       await sut.initialize();
-
-      streamController.add(false);
 
       expect(mock.initializeInvocationCounter, equals(0));
 
@@ -78,20 +75,18 @@ void main() {
     () async {
       final mock = MockTracker();
 
-      final streamController = StreamController<bool>(sync: true);
+      final valueNotifier = ValueNotifier<bool>(true);
 
       final sut = ConsentualTracker(
         () => mock,
-        streamController.stream,
+        valueNotifier,
       );
 
       await sut.initialize();
 
-      streamController.add(true);
-
       expect(mock.initializeInvocationCounter, equals(1));
 
-      streamController.add(false);
+      valueNotifier.value = false;
 
       expect(mock.destroyInvocationCounter, equals(1));
     },
@@ -102,20 +97,18 @@ void main() {
     () async {
       final mock = MockTracker();
 
-      final streamController = StreamController<bool>(sync: true);
+      final valueNotifier = ValueNotifier<bool>(false);
 
       final sut = ConsentualTracker(
         () => mock,
-        streamController.stream,
+        valueNotifier,
       );
 
       await sut.initialize();
 
-      streamController.add(false);
-
       expect(mock.initializeInvocationCounter, equals(0));
 
-      streamController.add(true);
+      valueNotifier.value = true;
 
       expect(mock.initializeInvocationCounter, equals(1));
     },

--- a/test/consentual_tracker_test.dart
+++ b/test/consentual_tracker_test.dart
@@ -16,10 +16,10 @@ class MockTracker extends AbstractTracker {
     trackedEvents.add(event);
   }
 
-  var destroyInvocationCounter = 0;
+  var closeInvocationCounter = 0;
   @override
-  Future<void> destroy() async {
-    destroyInvocationCounter += 1;
+  Future<void> close() async {
+    closeInvocationCounter += 1;
   }
 }
 
@@ -88,7 +88,7 @@ void main() {
 
       valueNotifier.value = false;
 
-      expect(mock.destroyInvocationCounter, equals(1));
+      expect(mock.closeInvocationCounter, equals(1));
     },
   );
 

--- a/test/consentual_tracker_test.dart
+++ b/test/consentual_tracker_test.dart
@@ -1,12 +1,24 @@
+import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
 
 class MockTracker extends AbstractTracker {
-  var trackedEvents = <AbstractEvent>[];
+  var initializeInvocationCounter = 0;
+  @override
+  Future<void> initialize() async {
+    initializeInvocationCounter += 1;
+  }
 
+  var trackedEvents = <AbstractEvent>[];
   @override
   Future<void> track(AbstractEvent event) async {
     trackedEvents.add(event);
+  }
+
+  var destroyInvocationCounter = 0;
+  @override
+  Future<void> destroy() async {
+    destroyInvocationCounter += 1;
   }
 }
 
@@ -18,10 +30,18 @@ void main() {
     () async {
       final mock = MockTracker();
 
+      final streamController = StreamController<bool>(sync: true);
+
       final sut = ConsentualTracker(
-        mock,
-        () async => true,
+        () => mock,
+        streamController.stream,
       );
+
+      await sut.initialize();
+
+      streamController.add(true);
+
+      expect(mock.initializeInvocationCounter, equals(1));
 
       await sut.track(event);
 
@@ -34,14 +54,70 @@ void main() {
     () async {
       final mock = MockTracker();
 
+      final streamController = StreamController<bool>(sync: true);
+
       final sut = ConsentualTracker(
-        mock,
-        () async => false,
+        () => mock,
+        streamController.stream,
       );
+
+      await sut.initialize();
+
+      streamController.add(false);
+
+      expect(mock.initializeInvocationCounter, equals(0));
 
       await sut.track(event);
 
       expect(mock.trackedEvents, equals([]));
+    },
+  );
+
+  test(
+    'If condition changes from true to false, underlying tracker is destroyed',
+    () async {
+      final mock = MockTracker();
+
+      final streamController = StreamController<bool>(sync: true);
+
+      final sut = ConsentualTracker(
+        () => mock,
+        streamController.stream,
+      );
+
+      await sut.initialize();
+
+      streamController.add(true);
+
+      expect(mock.initializeInvocationCounter, equals(1));
+
+      streamController.add(false);
+
+      expect(mock.destroyInvocationCounter, equals(1));
+    },
+  );
+
+  test(
+    'If condition changes from false to true, underlying tracker is initialised',
+    () async {
+      final mock = MockTracker();
+
+      final streamController = StreamController<bool>(sync: true);
+
+      final sut = ConsentualTracker(
+        () => mock,
+        streamController.stream,
+      );
+
+      await sut.initialize();
+
+      streamController.add(false);
+
+      expect(mock.initializeInvocationCounter, equals(0));
+
+      streamController.add(true);
+
+      expect(mock.initializeInvocationCounter, equals(1));
     },
   );
 }

--- a/test/consentual_tracker_test.dart
+++ b/test/consentual_tracker_test.dart
@@ -71,7 +71,7 @@ void main() {
   );
 
   test(
-    'If condition changes from true to false, underlying tracker is destroyed',
+    'If condition changes from true to false, underlying tracker is closed',
     () async {
       final mock = MockTracker();
 


### PR DESCRIPTION
AbstractTrackers allow initialisation and deallocation using the `initialise` and `destroy` method.

This allows us to deallocate the underlying native trackers to disable crash tracking etc., whenever the user revokes their tracking consent (GDPR requires this). 

Also moved ConsentualTracker to consume a stream and reactively initialise / destroy the underlying tracker.

Not 100% sure about naming, `destroy` sound weird. Maybe close is a better fit? WDYT?