### PR TITLE
Fixes SnowplowFlutterTracker.initialize

### DIFF
--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -36,9 +36,7 @@ class SnowplowFlutterTracker extends AbstractTracker {
   final Tracker _tracker;
 
   /// Constructor which always returns the original instance of the class.
-  SnowplowFlutterTracker(
-    this._tracker,
-  );
+  const SnowplowFlutterTracker(this._tracker);
 
   /// [initialize]
   /// The method which initializes the tracker instance of the current platform.

--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -30,25 +30,29 @@ class SnowplowFlutterTrackerInitialisationError extends Error {
 /// The class which communicates with the current platform.
 @immutable
 class SnowplowFlutterTracker extends AbstractTracker {
-  static final MethodChannel _channel =
-      MethodChannel('snowplow_flutter_tracker');
+  static const _channel = MethodChannel('snowplow_flutter_tracker');
   static var _isInitialized = false;
 
   final Tracker _tracker;
 
   /// Constructor which always returns the original instance of the class.
-  const SnowplowFlutterTracker(this._tracker);
+  SnowplowFlutterTracker(
+    this._tracker,
+  );
 
   /// [initialize]
   /// The method which initializes the tracker instance of the current platform.
   @override
   Future<void> initialize() async {
     if (_isInitialized) {
-      SnowplowFlutterTracker._isInitialized = true;
-      await _channel.invokeMethod('initialize', _tracker.toMap());
-    } else {
       throw SnowplowFlutterTrackerInitialisationError.alreadyInitialized();
     }
+
+    _isInitialized = true;
+    await _channel.invokeMethod(
+      'initialize',
+      _tracker.toMap(),
+    );
   }
 
   /// [setSubject]

--- a/test/snowplow_flutter_tracker_test.dart
+++ b/test/snowplow_flutter_tracker_test.dart
@@ -1,21 +1,62 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
 
 void main() {
   const channel = MethodChannel('snowplow_flutter_tracker');
+  final tracker = Tracker(
+    emitter: Emitter(uri: 'uri'),
+    appId: 'appID',
+    namespace: 'namespace',
+  );
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
-    });
-  });
+  group('[initialize]', () {
+    test(
+      "If tracker is not initialised, calls 'initialize' on platform channel",
+      () async {
+        var initialiseWasCalled = false;
 
-  group('SnowplowFlutterTracker', () {
-    test('Test', () {
-      expect(true, true);
-    });
+        final sut = SnowplowFlutterTracker(tracker);
+
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          initialiseWasCalled = true;
+
+          expect(methodCall.method, equals('initialize'));
+          expect(methodCall.arguments, equals(tracker.toMap()));
+          return;
+        });
+
+        await sut.initialize();
+
+        expect(initialiseWasCalled, equals(true));
+      },
+    );
+
+    test(
+      'If tracker is already initialised, throws an exception',
+      () async {
+        var initialiseWasCalled = false;
+
+        final sut = SnowplowFlutterTracker(tracker);
+
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          initialiseWasCalled = true;
+          return;
+        });
+
+        try {
+          await sut.initialize();
+        } on SnowplowFlutterTrackerInitialisationError {
+          expect(initialiseWasCalled, equals(false));
+        } catch (_) {
+          fail(
+            'Expected SnowplowFlutterTrackerInitialisationError to be thrown',
+          );
+        }
+      },
+    );
   });
 
   tearDown(() {


### PR DESCRIPTION
Just noticed while integrating the latest commit on Main into our application that initialising a SnowplowFlutterTracker is currently broken and only tries to initialise when it was already initialised, instead of initialising when it wasn't initialised yet. 🤦 

This PR fixes this and adds some tests.