### PR TITLE
Adds SnowplowFlutterTracker.close() tests

### DIFF
--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -33,6 +33,9 @@ class SnowplowFlutterTracker extends AbstractTracker {
   static const _channel = MethodChannel('snowplow_flutter_tracker');
   static var _isInitialized = false;
 
+  /// A flag indicating, if a SnowplowTracker was already initialised
+  static bool get isInitialized => _isInitialized;
+
   final Tracker _tracker;
 
   /// Constructor which always returns the original instance of the class.
@@ -91,6 +94,11 @@ class SnowplowFlutterTracker extends AbstractTracker {
 
   @override
   Future<void> close() async {
-    return _channel.invokeMethod('close');
+    if (!isInitialized) {
+      return;
+    }
+
+    await _channel.invokeMethod('close');
+    _isInitialized = false;
   }
 }

--- a/test/snowplow_flutter_tracker_test.dart
+++ b/test/snowplow_flutter_tracker_test.dart
@@ -2,6 +2,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
 
+/// ⚠️ Important ⚠️: For now, isInitialised is a static field.
+/// Therefore, the whole test suite needs to run in order,
+/// so that the flag has the correct value at the time the test is run.
+/// Make sure to not change the order of [initialize] and [close] tests
+/// or else this test suite will break!
 void main() {
   const channel = MethodChannel('snowplow_flutter_tracker');
   final tracker = Tracker(
@@ -31,6 +36,7 @@ void main() {
         await sut.initialize();
 
         expect(initialiseWasCalled, equals(true));
+        expect(SnowplowFlutterTracker.isInitialized, equals(true));
       },
     );
 
@@ -50,11 +56,55 @@ void main() {
           await sut.initialize();
         } on SnowplowFlutterTrackerInitialisationError {
           expect(initialiseWasCalled, equals(false));
+          expect(SnowplowFlutterTracker.isInitialized, equals(true));
         } catch (_) {
           fail(
             'Expected SnowplowFlutterTrackerInitialisationError to be thrown',
           );
         }
+      },
+    );
+  });
+
+  group('[close]', () {
+    test(
+      "If tracker is initialised, calls 'close' on platform channel",
+      () async {
+        var closeWasCalled = false;
+
+        final sut = SnowplowFlutterTracker(tracker);
+
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          closeWasCalled = true;
+
+          expect(methodCall.method, equals('close'));
+          return;
+        });
+
+        await sut.close();
+
+        expect(closeWasCalled, equals(true));
+        expect(SnowplowFlutterTracker.isInitialized, equals(false));
+      },
+    );
+
+    test(
+      "If tracker is not initialised, does not call 'close' on platform channel",
+      () async {
+        var closeWasCalled = false;
+
+        final sut = SnowplowFlutterTracker(tracker);
+
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          closeWasCalled = true;
+          expect(methodCall.method, equals('close'));
+          return;
+        });
+
+        await sut.close();
+
+        expect(closeWasCalled, equals(false));
+        expect(SnowplowFlutterTracker.isInitialized, equals(false));
       },
     );
   });


### PR DESCRIPTION
A bit too fast on the merge button. 😄 

I added some more tests for the .close() function as well.

Do you think, we should throw, when the library user tries to close a tracker that hasn't been initialised?