### PR TITLE
Enable/disable GDPR context at run-time

### DIFF
--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/MethodCallHandlerImpl.kt
@@ -24,6 +24,12 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
             "setSubject" -> {
                 onSetSubject(call, result)
             }
+            "enableGdprContext" -> {
+                onEnableGdprContext(call, result)
+            }
+            "disableGdprContext" -> {
+                onDisableGdprContext(result)
+            }
             "trackSelfDescribing" -> {
                 onTrackSelfDescribing(call, result)
             }
@@ -49,7 +55,7 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
                 onTrackConsentWithdrawn(call, result)
             }
             "close" -> {
-                onClose(call, result)
+                onClose(result)
             }
             else -> {
                 result.notImplemented()
@@ -87,6 +93,17 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
     private fun onSetSubject(call: MethodCall, result: MethodChannel.Result) {
         val subjectJson = call.arguments as Map<String, Any>?
         tracker?.setSubject(subjectJson)
+        result.success(null)
+    }
+
+    private fun onEnableGdprContext(call: MethodCall, result: MethodChannel.Result) {
+        val rawGdprContext = call.arguments as Map<String, Any>?
+        tracker?.enableGdprContext(rawGdprContext)
+        result.success(null)
+    }
+
+    private fun onDisableGdprContext(result: MethodChannel.Result) {
+        tracker?.disableGdprContext()
         result.success(null)
     }
 
@@ -138,7 +155,7 @@ class MethodCallHandlerImpl(private val context: Context) : MethodCallHandler {
         result.success(null)
     }
 
-    private fun onClose(call: MethodCall, result: MethodChannel.Result) {
+    private fun onClose(result: MethodChannel.Result) {
         tracker?.close()
         tracker = null
         result.success(null)

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/SnowplowFlutterTracker.kt
@@ -18,7 +18,24 @@ class SnowplowFlutterTracker(private val context: Context) {
 
     fun setSubject(json: Map<String, Any>?) {
         json?.let { SubjectUtil.configure(tracker.subject, it) }
-}
+    }
+
+    fun enableGdprContext(json: Map<String, Any>?) {
+        json?.let {
+            val basis = TrackerUtil.getGdprProcessingBasis(it);
+
+            tracker.enableGdprContext(
+                    basis,
+                    it["documentId"]?.toString(),
+                    it["documentVersion"]?.toString(),
+                    it["documentDescription"]?.toString()
+            )
+        }
+    }
+
+    fun disableGdprContext() {
+        tracker.disableGdprContext()
+    }
 
     fun trackSelfDescribingEvent(json: Map<String, Any>?) {
         val selfDescribing = EventUtil.getSelfDescribingEvent(json)

--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/TrackerUtil.kt
@@ -65,7 +65,7 @@ class TrackerUtil {
             return Tracker.init(builder.build())
         }
 
-        private fun getGdprProcessingBasis(context: Map<String, Any>): Gdpr.Basis {
+        fun getGdprProcessingBasis(context: Map<String, Any>): Gdpr.Basis {
             val basis = context["basis"] as? String
             if (basis != null) {
                 return when(basis) {

--- a/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowFlutterTrackerPlugin.swift
@@ -17,6 +17,10 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
             onInitialize(call, result)
         case "setSubject":
             onSetSubject(call, result)
+        case "enableGdprContext":
+            onEnableGdprContext(call, result)
+        case "disableGdprContext":
+            onDisableGdprContext(call, result)
         case "trackPageView":
             onTrackPageView(call, result)
         case "trackStructured":
@@ -56,6 +60,25 @@ public class SwiftSnowplowFlutterTrackerPlugin: NSObject, FlutterPlugin {
             tracker?.subject.configure(with: subjectConfiguration)
         }
 
+        result(nil)
+    }
+
+    private func onEnableGdprContext(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        if let rawGdprContext = call.arguments as? [String: Any],
+           let gdprContext = TrackerUtil.GDPRContext(from: rawGdprContext){
+            tracker?.enableGdprContext(
+                with: gdprContext.processingBasis,
+                documentId: gdprContext.documentId,
+                documentVersion: gdprContext.documentVersion,
+                documentDescription: gdprContext.documentDescription
+            )
+        }
+
+        result(nil)
+    }
+
+    private func onDisableGdprContext(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        tracker?.disableGdprContext()
         result(nil)
     }
     

--- a/lib/src/snowplow_flutter_tracker.dart
+++ b/lib/src/snowplow_flutter_tracker.dart
@@ -17,6 +17,7 @@ import 'events/timing.dart';
 import 'tracker/abstract_tracker.dart';
 import 'tracker/subject.dart';
 import 'tracker/tracker.dart';
+import 'tracker/gdpr_context.dart';
 
 /// [SnowplowFlutterTrackerInitialisationError]
 ///
@@ -38,11 +39,9 @@ class SnowplowFlutterTracker extends AbstractTracker {
 
   final Tracker _tracker;
 
-  /// Constructor which always returns the original instance of the class.
+  /// Constructs a SnowplowFlutterTracker instance.
   const SnowplowFlutterTracker(this._tracker);
 
-  /// [initialize]
-  /// The method which initializes the tracker instance of the current platform.
   @override
   Future<void> initialize() async {
     if (_isInitialized) {
@@ -56,10 +55,19 @@ class SnowplowFlutterTracker extends AbstractTracker {
     );
   }
 
-  /// [setSubject]
-  /// Sets the subject on the platform's tracker instance.
+  @override
   Future<void> setSubject(Subject subject) async {
-    return await _channel.invokeMethod('setSubject', subject.toMap());
+    await _channel.invokeMethod('setSubject', subject.toMap());
+  }
+
+  @override
+  Future<void> enableGdprContext(GDPRContext context) async {
+    await _channel.invokeMethod('enableGdprContext', context.toMap());
+  }
+
+  @override
+  Future<void> disableGdprContext() async {
+    await _channel.invokeMethod('disableGdprContext');
   }
 
   @override

--- a/lib/src/tracker/abstract_tracker.dart
+++ b/lib/src/tracker/abstract_tracker.dart
@@ -1,6 +1,6 @@
-import 'package:snowplow_flutter_tracker/snowplow_flutter_tracker.dart';
-
 import '../events/abstract_event.dart';
+import 'gdpr_context.dart';
+import 'subject.dart';
 
 /// [AbstractTracker]
 /// An abstract tracker allows to track events
@@ -11,6 +11,18 @@ abstract class AbstractTracker {
   /// [initialize]
   /// Initializes the tracker.
   Future<void> initialize();
+
+  /// [setSubject]
+  /// Sets the subject on the platform's tracker instance.
+  Future<void> setSubject(Subject subject);
+
+  /// [enableGdprContext]
+  /// Enables GDPR context to be sent with every event.
+  Future<void> enableGdprContext(GDPRContext context);
+
+  /// [disableGdprContext]
+  /// Disables GDPR context.
+  Future<void> disableGdprContext();
 
   /// [track]
   /// Tracks the given [event] parameter by the platform's tracker instance.

--- a/lib/src/tracker/trackers/global_context_provider.dart
+++ b/lib/src/tracker/trackers/global_context_provider.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 
 import '../abstract_tracker.dart';
+import '../gdpr_context.dart';
+import '../subject.dart';
 import '../../events/abstract_event.dart';
 import '../../events/self_describing_json.dart';
 
@@ -25,6 +27,16 @@ class GlobalContextProvider extends AbstractTracker {
 
   @override
   Future<void> initialize() => _child.initialize();
+
+  @override
+  Future<void> setSubject(Subject subject) => _child.setSubject(subject);
+
+  @override
+  Future<void> enableGdprContext(GDPRContext context) =>
+      _child.enableGdprContext(context);
+
+  @override
+  Future<void> disableGdprContext() => _child.disableGdprContext();
 
   @override
   Future<void> track(AbstractEvent event) async => _child.track(

--- a/lib/src/tracker/trackers/tracking_guard.dart
+++ b/lib/src/tracker/trackers/tracking_guard.dart
@@ -2,6 +2,8 @@ import 'package:meta/meta.dart';
 
 import '../../events/abstract_event.dart';
 import '../abstract_tracker.dart';
+import '../gdpr_context.dart';
+import '../subject.dart';
 
 /// A [TrackingGuard] only forwards events
 /// to its child if shouldTrack evaluates truthy.
@@ -19,6 +21,16 @@ class TrackingGuard extends AbstractTracker {
 
   @override
   Future<void> initialize() => _child.initialize();
+
+  @override
+  Future<void> setSubject(Subject subject) => _child.setSubject(subject);
+
+  @override
+  Future<void> enableGdprContext(GDPRContext context) =>
+      _child.enableGdprContext(context);
+
+  @override
+  Future<void> disableGdprContext() => _child.disableGdprContext();
 
   @override
   Future<void> track(AbstractEvent event) async {

--- a/test/snowplow_flutter_tracker_test.dart
+++ b/test/snowplow_flutter_tracker_test.dart
@@ -30,7 +30,6 @@ void main() {
 
           expect(methodCall.method, equals('initialize'));
           expect(methodCall.arguments, equals(tracker.toMap()));
-          return;
         });
 
         await sut.initialize();
@@ -49,7 +48,6 @@ void main() {
 
         channel.setMockMethodCallHandler((MethodCall methodCall) async {
           initialiseWasCalled = true;
-          return;
         });
 
         try {
@@ -78,7 +76,6 @@ void main() {
           closeWasCalled = true;
 
           expect(methodCall.method, equals('close'));
-          return;
         });
 
         await sut.close();
@@ -98,7 +95,6 @@ void main() {
         channel.setMockMethodCallHandler((MethodCall methodCall) async {
           closeWasCalled = true;
           expect(methodCall.method, equals('close'));
-          return;
         });
 
         await sut.close();
@@ -108,6 +104,67 @@ void main() {
       },
     );
   });
+
+  test(
+    '[setSubject] Calls setSubject on platform channel',
+    () async {
+      var setSubjectCalled = false;
+      var subject = Subject(domainUserId: 'domainUserID');
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        setSubjectCalled = true;
+
+        expect(methodCall.method, equals('setSubject'));
+        expect(methodCall.arguments, equals(subject.toMap()));
+      });
+
+      final sut = SnowplowFlutterTracker(tracker);
+
+      await sut.setSubject(subject);
+
+      expect(setSubjectCalled, equals(true));
+    },
+  );
+
+  test(
+    '[enableGDPRContext] Calls enableGDPRContext on platform channel',
+    () async {
+      var enableGDPRContextCalled = false;
+      var gdprContext = GDPRContext(basis: GDPRLegalBasis.consent);
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        enableGDPRContextCalled = true;
+
+        expect(methodCall.method, equals('enableGdprContext'));
+        expect(methodCall.arguments, equals(gdprContext.toMap()));
+      });
+
+      final sut = SnowplowFlutterTracker(tracker);
+
+      await sut.enableGdprContext(gdprContext);
+
+      expect(enableGDPRContextCalled, equals(true));
+    },
+  );
+
+  test(
+    '[disableGdprContext] Calls enableGDPRContext on platform channel',
+    () async {
+      var disableGdprContextCalled = false;
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        disableGdprContextCalled = true;
+
+        expect(methodCall.method, equals('disableGdprContext'));
+      });
+
+      final sut = SnowplowFlutterTracker(tracker);
+
+      await sut.disableGdprContext();
+
+      expect(disableGdprContextCalled, equals(true));
+    },
+  );
 
   tearDown(() {
     channel.setMockMethodCallHandler(null);

--- a/test/tracking_guard_test.dart
+++ b/test/tracking_guard_test.dart
@@ -6,8 +6,52 @@ import 'utils/mock_tracker.dart';
 void main() {
   final event = ScreenView(name: 'name');
 
+  test('[initialize] Calls initialize on child tracker', () async {
+    final mock = MockTracker();
+
+    final sut = TrackingGuard(
+      child: mock,
+      shouldTrack: (_) async => true,
+    );
+
+    await sut.initialize();
+
+    expect(mock.initializeInvocationCounter, equals(1));
+  });
+
+  test('[setSubject] Calls setSubject on child tracker', () async {
+    final mock = MockTracker();
+    final subject = Subject();
+
+    final sut = TrackingGuard(
+      child: mock,
+      shouldTrack: (_) async => true,
+    );
+
+    await sut.setSubject(subject);
+
+    expect(mock.setSubjectInvocations, equals([subject]));
+  });
+
   test(
-    'If condition is true, TrackingGuard forwards events',
+    '[enableGdprContext] Calls enableGdprContext on child tracker',
+    () async {
+      final mock = MockTracker();
+      final context = GDPRContext(basis: GDPRLegalBasis.consent);
+
+      final sut = TrackingGuard(
+        child: mock,
+        shouldTrack: (_) async => true,
+      );
+
+      await sut.enableGdprContext(context);
+
+      expect(mock.enableGdprContextInvocations, equals([context]));
+    },
+  );
+
+  test(
+    '[disableGdprContext] Calls disableGdprContext on child tracker',
     () async {
       final mock = MockTracker();
 
@@ -16,25 +60,56 @@ void main() {
         shouldTrack: (_) async => true,
       );
 
-      await sut.track(event);
+      await sut.disableGdprContext();
 
-      expect(mock.trackedEvents, equals([event]));
+      expect(mock.disableGdprContextInvocationCount, equals(1));
     },
   );
 
-  test(
-    'If condition is false, TrackingGuard does not forward events',
-    () async {
-      final mock = MockTracker();
+  group('[track]', () {
+    test(
+      'If condition is true, TrackingGuard forwards events',
+      () async {
+        final mock = MockTracker();
 
-      final sut = TrackingGuard(
-        child: mock,
-        shouldTrack: (_) async => false,
-      );
+        final sut = TrackingGuard(
+          child: mock,
+          shouldTrack: (_) async => true,
+        );
 
-      await sut.track(event);
+        await sut.track(event);
 
-      expect(mock.trackedEvents, equals([]));
-    },
-  );
+        expect(mock.trackedEvents, equals([event]));
+      },
+    );
+
+    test(
+      'If condition is false, TrackingGuard does not forward events',
+      () async {
+        final mock = MockTracker();
+
+        final sut = TrackingGuard(
+          child: mock,
+          shouldTrack: (_) async => false,
+        );
+
+        await sut.track(event);
+
+        expect(mock.trackedEvents, equals([]));
+      },
+    );
+  });
+
+  test('[close] Calls close on child tracker', () async {
+    final mock = MockTracker();
+
+    final sut = TrackingGuard(
+      child: mock,
+      shouldTrack: (_) async => true,
+    );
+
+    await sut.close();
+
+    expect(mock.closeInvocationCounter, equals(1));
+  });
 }

--- a/test/utils/mock_tracker.dart
+++ b/test/utils/mock_tracker.dart
@@ -7,6 +7,24 @@ class MockTracker extends AbstractTracker {
     initializeInvocationCounter += 1;
   }
 
+  var setSubjectInvocations = <Subject>[];
+  @override
+  Future<void> setSubject(Subject subject) async {
+    setSubjectInvocations.add(subject);
+  }
+
+  var enableGdprContextInvocations = <GDPRContext>[];
+  @override
+  Future<void> enableGdprContext(GDPRContext context) async {
+    enableGdprContextInvocations.add(context);
+  }
+
+  var disableGdprContextInvocationCount = 0;
+  @override
+  Future<void> disableGdprContext() async {
+    disableGdprContextInvocationCount += 1;
+  }
+
   var trackedEvents = <AbstractEvent>[];
   @override
   Future<void> track(AbstractEvent event) async {


### PR DESCRIPTION
Resolves #27.

Also added tests for some functionalities and exposed setSubject() via the AbstractTracker.

Maybe we should rename AbstractTracker to AbstractSnowplowTracker. WDYT?