### PR TITLE
Fixes attaching contexts to structured and unstructured events

### DIFF
--- a/ios/Classes/EventUtil.swift
+++ b/ios/Classes/EventUtil.swift
@@ -14,7 +14,7 @@ struct EventUtil {
             SPPageViewBuilder.setPageUrl(dict?["pageUrl"] as! String)
             SPPageViewBuilder.setPageTitle(dict?["pageTitle"] as? String)
             SPPageViewBuilder.setReferrer(dict?["referrer"] as? String)
-            SPPageViewBuilder.setContexts(getContexts(dict))
+            getContexts(dict).map(SPPageViewBuilder.setContexts)
         }
     }
     

--- a/ios/Classes/EventUtil.swift
+++ b/ios/Classes/EventUtil.swift
@@ -27,7 +27,7 @@ struct EventUtil {
             SPStructuredBuilder.setProperty(dict?["property"] as? String)
             (dict?["value"] as? Double).map(SPStructuredBuilder.setValue)
 
-            SPStructuredBuilder.setContexts(getContexts(dict))
+            getContexts(dict).map(SPStructuredBuilder.setContexts)
         }
     }
     
@@ -36,7 +36,7 @@ struct EventUtil {
         
         return SPUnstructured.build { (SPUnstructuredBuilder) in
             SPUnstructuredBuilder.setEventData(eventData)
-            SPUnstructuredBuilder.setContexts(getContexts(dict))
+            getContexts(dict).map(SPUnstructuredBuilder.setContexts)
         }
     }
     


### PR DESCRIPTION
Sending a structured/unstructured event without attached contexts crashed the application as snowplow-objc-tracker expects a non-null value in .setContexts(). 

Fixed by mapping (.let { it } for all Kotlin devs) .setContexts to the unwrapped contexts, making sure that only non-null values are passed to setContexts.