### PR TITLE
Marks expiry as non-optional in ConsentGranted event

### DIFF
--- a/lib/src/events/consent_granted.dart
+++ b/lib/src/events/consent_granted.dart
@@ -14,7 +14,7 @@ class ConsentGranted implements AbstractEvent {
   final String documentVersion;
 
   /// [expiry] The associated consent document expiry.
-  final String? expiry;
+  final String expiry;
 
   /// [documentName] The associated consent document name.
   final String? documentName;
@@ -32,13 +32,14 @@ class ConsentGranted implements AbstractEvent {
   ConsentGranted({
     required this.documentId,
     required this.documentVersion,
-    this.expiry,
+    required this.expiry,
     this.documentName,
     this.documentDescription,
     this.consentDocuments = const [],
     this.contexts = const {},
   })  : assert(documentId.isNotEmpty, 'documentId cannot be empty'),
-        assert(documentVersion.isNotEmpty, 'documentVersion cannot be empty');
+        assert(documentVersion.isNotEmpty, 'documentVersion cannot be empty'),
+        assert(expiry.isNotEmpty, 'expiry cannot be empty');
 
   @override
   Map<String, Object?> toMap() {


### PR DESCRIPTION
<img width="571" alt="Screenshot 2021-05-03 at 10 21 38" src="https://user-images.githubusercontent.com/9058860/116855500-c4174d80-abf9-11eb-9f84-28652a150c1c.png">

According to the Android Snowplow SDK, expiry is a @non-null field in ConsentGranted events. Therefore, we should also mark as non-optional in the Dart interface.